### PR TITLE
(Chore) OpenID config

### DIFF
--- a/acc.config.json
+++ b/acc.config.json
@@ -40,6 +40,8 @@
   "theme": {},
   "ROOT": "https://acc.meldingen.amsterdam.nl/",
   "AUTH_ROOT": "https://acc.api.data.amsterdam.nl/",
+  "OIDC_CLIENT_ID": "sia",
+  "OIDC_AUTH_ENDPOINT": "https://acc.api.data.amsterdam.nl/oauth2/authorize",
   "API_ROOT_MAPSERVER": "https://map.data.amsterdam.nl/",
   "USERS_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/users/",
   "ROLES_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/roles/",

--- a/prod.config.json
+++ b/prod.config.json
@@ -56,6 +56,8 @@
   "theme": {},
   "ROOT": "https://meldingen.amsterdam.nl/",
   "AUTH_ROOT": "https://api.data.amsterdam.nl/",
+  "OIDC_CLIENT_ID": "sia",
+  "OIDC_AUTH_ENDPOINT": "https://api.data.amsterdam.nl/oauth2/authorize",
   "API_ROOT_MAPSERVER": "https://map.data.amsterdam.nl/",
   "USERS_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/users/",
   "ROLES_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/roles/",


### PR DESCRIPTION
This PR adds OpenID config settings, in preparation of merging https://github.com/Amsterdam/signals-frontend/pull/858.
Note that, after merging, the config setting `AUTH_ROOT` has become obsolete and can be removed permanently.