### PR TITLE
(Chore) Configuration STATIC_MAP_SERVER_URL

### DIFF
--- a/acc.config.json
+++ b/acc.config.json
@@ -58,6 +58,7 @@
   "OIDC_RESPONSE_TYPE": "token",
   "OIDC_SCOPE": "SIG/ALL",
   "OIDC_AUTH_ENDPOINT": "https://acc.api.data.amsterdam.nl/oauth2/authorize",
+  "API_ROOT_MAPSERVER": "https://map.data.amsterdam.nl/",
   "STATIC_MAP_SERVER_URL": "https://map.data.amsterdam.nl/maps/topografie",
   "USERS_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/users/",
   "ROLES_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/roles/",

--- a/acc.config.json
+++ b/acc.config.json
@@ -58,7 +58,7 @@
   "OIDC_RESPONSE_TYPE": "token",
   "OIDC_SCOPE": "SIG/ALL",
   "OIDC_AUTH_ENDPOINT": "https://acc.api.data.amsterdam.nl/oauth2/authorize",
-  "API_ROOT_MAPSERVER": "https://map.data.amsterdam.nl/",
+  "STATIC_MAP_SERVER_URL": "https://map.data.amsterdam.nl/maps/topografie",
   "USERS_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/users/",
   "ROLES_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/roles/",
   "PERMISSIONS_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/permissions/",

--- a/prod.config.json
+++ b/prod.config.json
@@ -74,7 +74,7 @@
   "OIDC_RESPONSE_TYPE": "token",
   "OIDC_SCOPE": "SIG/ALL",
   "OIDC_AUTH_ENDPOINT": "https://api.data.amsterdam.nl/oauth2/authorize",
-  "API_ROOT_MAPSERVER": "https://map.data.amsterdam.nl/",
+  "STATIC_MAP_SERVER_URL": "https://map.data.amsterdam.nl/maps/topografie",
   "USERS_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/users/",
   "ROLES_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/roles/",
   "PERMISSIONS_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/permissions/",

--- a/prod.config.json
+++ b/prod.config.json
@@ -74,6 +74,7 @@
   "OIDC_RESPONSE_TYPE": "token",
   "OIDC_SCOPE": "SIG/ALL",
   "OIDC_AUTH_ENDPOINT": "https://api.data.amsterdam.nl/oauth2/authorize",
+  "API_ROOT_MAPSERVER": "https://map.data.amsterdam.nl/",
   "STATIC_MAP_SERVER_URL": "https://map.data.amsterdam.nl/maps/topografie",
   "USERS_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/users/",
   "ROLES_ENDPOINT": "https://api.data.amsterdam.nl/signals/v1/private/roles/",


### PR DESCRIPTION
Adds `STATIC_MAP_SERVER_URL` prop to replace `API_ROOT_MAPSERVER`. Leaves `API_ROOT_MAPSERVER` in for backwards compatibility; can be removed once https://github.com/Amsterdam/signals-frontend/pull/990 has been merged.